### PR TITLE
Do not pass down internal props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -240,6 +240,7 @@ export function createScrollingComponent(WrappedComponent) {
         verticalStrength,
         horizontalStrength,
         onScrollChange,
+        dragDropManager,
 
         ...props
       } = this.props;


### PR DESCRIPTION
Currently, `dragDropManager` is passed down to the `WrappedComponent` which is usually a DOM element.
Do not pass it down anymore.

https://www.useloom.com/share/06b2f2a11b0e4b9193c0fb3b39e7f677