### PR TITLE
fix: prevent dragDropManager to be passed down to ScrollingComponent children

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -236,6 +236,7 @@ export function createScrollingComponent(WrappedComponent) {
     render() {
       const {
         // not passing down these props
+        dragDropManager,
         strengthMultiplier,
         verticalStrength,
         horizontalStrength,


### PR DESCRIPTION
Hello guys,

This fix will remove warning : React does not recognize the `dragDropManager` prop on a DOM element.

Regards,