### PR TITLE
Remove react and react-dom from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,7 @@
     "eslint-plugin-react": "^7.11.1",
     "in-publish": "^2.0.0",
     "mocha": "^5.2.0",
-    "react": "^16.3.0",
     "react-dnd": "^7.3.0",
-    "react-dom": "^16.3.0",
     "sinon": "^7.1.1",
     "sinon-chai": "^3.2.0"
   },


### PR DESCRIPTION
It breaks dependency tree (scheduler@0.13.6 should be 0.15.0) when updating to react@16.9